### PR TITLE
Laravel 12.x support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,12 +17,15 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 8.3, 8.2 ]
-        laravel: [ 11.*]
+        php: [ 8.4, 8.3, 8.2 ]
+        laravel: [ 11.*, 12.* ]
         stability: [ prefer-lowest, prefer-stable ]
         include:
           - laravel: 11.*
             testbench: 9.*
+            carbon: ^3.0
+          - laravel: 12.*
+            testbench: 10.*
             carbon: ^3.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.2",
         "spatie/laravel-package-tools": "^1.16",
-        "illuminate/contracts": "^10.0||^11.0"
+        "illuminate/contracts": "^10.0||^11.0||^12.0"
     },
     "require-dev": {
         "laravel/pint": "^1.14",


### PR DESCRIPTION
## Summary

Laravel 11.x reaches security fix EOL next month so 12.x support will be required going forward.

Also added PHP 8.4 to test runs.

Laravel v13.0.0 will likely be released within the next few weeks.

## Links

* https://laravel.com/docs/12.x/releases
* https://github.com/laravel/framework/tree/13.x
* https://www.php.net/supported-versions.php